### PR TITLE
Update openlab scripts

### DIFF
--- a/Include/bmcop.sh
+++ b/Include/bmcop.sh
@@ -5,17 +5,17 @@
 #############################################################################
 get_bmc_op_cmd()
 {
-	(
-	bmc="BMC$1"
+	local bmc="BMC$1"
 	shift
-	bmc_op=$@
-	bmc_info=$(grep -P "^($bmc:).*" $OPENLAB_CONF_DIR/$BMC_INFO_FILE)
-	bmc_ip=$(echo "$bmc_info" | grep -Po "(?<=ip=)([^,]*)")
-	bmc_account=$(echo "$bmc_info" | grep -Po "(?<=account=)([^,]*)")
-	bmc_pass=$(echo "$bmc_info" | grep -Po "(?<=pass=)([^,]*)")
-	bmc_op_cmd="ipmitool -H $bmc_ip -I lanplus -U $bmc_account -P $bmc_pass $bmc_op"
+
+	local bmc_op=$@
+	local bmc_info=$(grep -P "^($bmc:).*" $OPENLAB_CONF_DIR/$BMC_INFO_FILE)
+	local bmc_ip=$(echo "$bmc_info" | grep -Po "(?<=ip=)([^,]*)")
+	local bmc_if=$(echo "$bmc_info" | grep -Po "(?<=interface=)([^,]*)")
+	local bmc_account=$(echo "$bmc_info" | grep -Po "(?<=account=)([^,]*)")
+	local bmc_pass=$(echo "$bmc_info" | grep -Po "(?<=pass=)([^,]*)")
+	local bmc_op_cmd="ipmitool -H $bmc_ip -I $bmc_if -U $bmc_account -P $bmc_pass $bmc_op"
 	echo $bmc_op_cmd
-	)
 }
 
 #############################################################################
@@ -99,8 +99,8 @@ bmc_power()
 #############################################################################
 bmc_serial_ex()
 {
-	bmc_no=$1
-	sol_op=$2
+	local bmc_no=$1
+	local sol_op=$2
 
 	case $sol_op in
 	"connect")

--- a/Include/board_power_op.sh
+++ b/Include/board_power_op.sh
@@ -5,17 +5,15 @@
 #############################################################################
 board_power_ex()
 {
-	board_no=$1
-	power_op=$2
-	board_info=$(grep -P "^(BOARD$board_no:).*" $OPENLAB_CONF_DIR/boardinfo.cfg)
-
-	power_info=$(echo "$board_info" | grep -Po "(?<=power=)([^,]*)")
-	power_type=$(echo "$power_info" | grep -Po "(PDU|BMC)")
-	power_args=($(echo ${power_info#$power_type}))
-	power_index=${power_args[0]}
+	local power_op=$2
+	local board_info=$(get_board_info $1)
+	local power_info=$(echo "$board_info" | grep -Po "(?<=power=)([^,]*)")
+	local power_type=$(echo "$power_info" | grep -Po "(PDU|BMC)")
+	local power_args=($(echo ${power_info#$power_type}))
+	local power_index=${power_args[0]}
 
 	if [ x"$power_type" = x"PDU" ]; then
-		pdu_outlet=${power_args[1]}
+		local pdu_outlet=${power_args[1]}
 		pdu_power $power_index $pdu_outlet $power_op
 	else
 		bmc_power $power_index $power_op

--- a/Include/board_serial_op.sh
+++ b/Include/board_serial_op.sh
@@ -5,14 +5,11 @@
 #############################################################################
 board_serial_ex()
 {
-	board_no=$1
-	ser_op=$2
-	
-	board_info=$(grep -P "^(BOARD$board_no:).*" $OPENLAB_CONF_DIR/boardinfo.cfg)
-
-	serial=$(echo "$board_info" | grep -Po "(?<=serno=)([^ ,]*)")
-	serial_type=$(echo "$serial" | grep -Po "(TELNET|BMC)")
-	serial_no=${serial#$serial_type}
+	local ser_op=$2
+	local board_info=$(get_board_info $1)
+	local serial=$(echo "$board_info" | grep -Po "(?<=serno=)([^ ,]*)")
+	local serial_type=$(echo "$serial" | grep -Po "(TELNET|BMC)")
+	local serial_no=${serial#$serial_type}
 
 	if [ x"$serial_type" = x"TELNET" ]; then
 		telnet_serial $serial_no $ser_op

--- a/Include/pduop.sh
+++ b/Include/pduop.sh
@@ -5,15 +5,16 @@
 #############################################################################
 send_cmd_to_pdu_ex()
 {
-	pdu_on=1
-	pdu_off=2
-	pdu_reset=3
+	local pdu_on=1
+	local pdu_off=2
+	local pdu_reset=3
 	
-	pdu_no=$1
-	outlet=$2
-	pdu_op=$3
-	pdu_ip=$(grep -P "^(PDU$pdu_no).*" $OPENLAB_CONF_DIR/$PDU_INFO_FILE | grep -Po "(?<=ip=)([^,]*)")
+	local pdu_no=$1
+	local outlet=$2
+	local pdu_op=$3
+	local pdu_ip=$(grep -P "^(PDU$pdu_no).*" $OPENLAB_CONF_DIR/$PDU_INFO_FILE | grep -Po "(?<=ip=)([^,]*)")
 	eval op=\$pdu_$pdu_op
+
 	exec ap7921-control $pdu_ip $outlet $op
 }
 

--- a/Include/telnetop.sh
+++ b/Include/telnetop.sh
@@ -5,14 +5,12 @@
 #############################################################################
 get_telnet_connect_cmd()
 {
-	(
-		telnet="TELNET$1"
-		telnet_info=$(grep -P "^($telnet:).*" $OPENLAB_CONF_DIR/$TELNET_INFO_FILE)
-		telnet_ip=$(echo "$telnet_info" | grep -Po "(?<=ip=)([^,]*)")
-		telnet_port=$(echo "$telnet_info" | grep -Po "(?<=port=)([^,]*)")
-		telnet_op_cmd="telnet $telnet_ip $telnet_port"
-		echo $telnet_op_cmd
-	)
+	local telnet="TELNET$1"
+	local telnet_info=$(grep -P "^($telnet:).*" $OPENLAB_CONF_DIR/$TELNET_INFO_FILE)
+	local telnet_ip=$(echo "$telnet_info" | grep -Po "(?<=ip=)([^,]*)")
+	local telnet_port=$(echo "$telnet_info" | grep -Po "(?<=port=)([^,]*)")
+	local telnet_op_cmd="telnet $telnet_ip $telnet_port"
+	echo $telnet_op_cmd
 }
 
 #############################################################################
@@ -21,11 +19,10 @@ get_telnet_connect_cmd()
 telnet_connect()
 {
 	(
-	 telnet="TELNET$1"
-	 telnet_info=$(grep -P "^($telnet:).*" $OPENLAB_CONF_DIR/$TELNET_INFO_FILE)
-	 telnet_ip=$(echo "$telnet_info" | grep -Po "(?<=ip=)([^,]*)")
-	 telnet_port=$(echo "$telnet_info" | grep -Po "(?<=port=)([^,]*)")
-	 exec telnet $telnet_ip $telnet_port
+	telnet_op_cmd=$(get_telnet_connect_cmd $@)
+	if [ x"$telnet_op_cmd" != x"" ]; then
+		exec $telnet_op_cmd
+	fi
 	)
 }
 
@@ -49,8 +46,8 @@ telnet_disconnect()
 #############################################################################
 telnet_serial_ex()
 {
-	telnet_no=$1
-	telnet_op=$2
+	local telnet_no=$1
+	local telnet_op=$2
 	case $telnet_op in
 	"connect")
 		telnet_connect $telnet_no ;;

--- a/Include/userop.sh
+++ b/Include/userop.sh
@@ -48,6 +48,7 @@ get_user_info()
 	local usr=$1
 	local usr_info=$(grep -P "^($usr:).*" $OPENLAB_CONF_DIR/$USER_INFO_FILE)
 	echo $usr_info
+
 	if [ x"$usr_info" != x"" ]; then
 		return 0
 	else

--- a/Include/userop.sh
+++ b/Include/userop.sh
@@ -56,5 +56,16 @@ get_user_info()
 	fi
 }
 
+#############################################################################
+# check_user usr
+#############################################################################
+check_user()
+{
+	local usr=$1
+	if !(get_user_info $usr >/dev/null); then
+		echo -e "\033[31mYou are not permited to use the board in OpenLab.\033[0m"
+		return 1
+	fi
 
-
+	return 0
+}

--- a/board_connect
+++ b/board_connect
@@ -32,7 +32,7 @@ Usage()
     echo "Usage: board_connect [Num]"
     echo "    -h     : Display this information"
     echo "    Num    : To use the specified board assigned to user, Num is an interger board index which must be greater than 0, default to use No.1 board."
-	exit
+    exit
 }
 
 #############################################################################
@@ -83,14 +83,13 @@ done
 # Get BOARD_NO
 #############################################################################
 if [ x"$BOARD_NO" = x"" ]; then
+	user_boards=($(get_user_boards $USER))
 	if [ x"$BOARD_INDEX" != x"" ]; then
-		user_boards=($(get_user_boards $USER))
 		if [ $BOARD_INDEX -lt 0 ] || [ $BOARD_INDEX -ge ${#user_boards[@]} ]; then
 			echo -e "\033[31mInvalid board index! Please use board_list to get your board info!\033[0m" >&2 ; exit 1
 		fi
 		BOARD_NO=${user_boards[$BOARD_INDEX]}
 	else
-		user_boards=($(get_user_boards $USER))
 		BOARD_NO=${user_boards[0]}
 	fi
 fi

--- a/board_connect
+++ b/board_connect
@@ -38,8 +38,7 @@ Usage()
 #############################################################################
 # Check if user is in openlab user list
 #############################################################################
-if !(get_user_info $USER >/dev/null); then
-	echo "You are not permited to use the board in OpenLab."
+if !(check_user $USER); then
 	exit 1
 fi
 
@@ -82,40 +81,54 @@ done
 #############################################################################
 # Get BOARD_NO
 #############################################################################
+BOARD_NO=$(get_board_no $USER $BOARD_INDEX)
 if [ x"$BOARD_NO" = x"" ]; then
-	user_boards=($(get_user_boards $USER))
-	if [ x"$BOARD_INDEX" != x"" ]; then
-		if [ $BOARD_INDEX -lt 0 ] || [ $BOARD_INDEX -ge ${#user_boards[@]} ]; then
-			echo -e "\033[31mInvalid board index! Please use board_list to get your board info!\033[0m" >&2 ; exit 1
-		fi
-		BOARD_NO=${user_boards[$BOARD_INDEX]}
-	else
-		BOARD_NO=${user_boards[0]}
-	fi
+	echo -e "\033[31mInvalid boardNo! Please use board_list to get your board info!\033[0m" >&2 ;
+	exit 1
 fi
 
 #############################################################################
 # Check if board is deployed or being used 
 #############################################################################
-if !(get_board_info $BOARD_NO >/dev/null); then
-	echo -e "\033[31mCan't find board info! Please touch Lab admin to get more help!\033[0m" ; exit 0
-fi
-
 if !(board_deploy_chk $BOARD_NO); then
 	exit 1
 fi
 
-if !(board_using_chk $BOARD_NO connect); then
+if !(board_using_chk $USER $BOARD_NO); then
 	exit 1
+fi
+
+curUser=$(get_board_current_user $BOARD_NO)
+if [ x"$curUser" != x"" ]; then
+	echo "You are using another session connected to the board."
+	read -n1 -p "Do you want to kill it and try a new session [Y/N]?" answer
+	case $answer in
+	Y | y)
+		echo  -e "\n fine ,continue"
+		close_board_connect $BOARD_NO
+		pid=`get_board_connect_pid $BOARD_NO`
+		if [ x"$pid" != x"" ]; then
+			kill -s 9 $pid
+		fi
+		;;
+	N | n)
+		echo -e "\n ok,good bye" ;
+		exit 1
+		;;
+	*)
+		echo -e  "\n Sorry! Error choice";
+		exit 1
+		;;
+	esac
 fi
 
 #############################################################################
 # Connect to Target Board
 #############################################################################
-board_file_copy $BOARD_NO
+board_file_prepare $BOARD_NO
 
-board_connect_cmd=$(get_board_connect_cmd $BOARD_NO)
 board_type=$(get_board_type $BOARD_NO)
+board_connect_cmd=$(get_board_connect_cmd $BOARD_NO)
 echo -e "\033[32mConnected to board: No=$BOARD_NO, type=$board_type.\033[0m"
 exec $board_connect_cmd
 

--- a/board_list
+++ b/board_list
@@ -5,8 +5,6 @@ export PATH=$TOP_DIR/bin:$PATH
 OPENLAB_TOPDIR=/usr/local/openlab
 OPENLAB_CONF_DIR=$OPENLAB_TOPDIR/openlab_conf
 
-USER=${1:-`whoami`}
-
 #############################################################################
 # Source common variables and user functions
 #############################################################################
@@ -14,10 +12,31 @@ USER=${1:-`whoami`}
 . $OPENLAB_TOPDIR/Include/userop.sh
 
 #############################################################################
+# Usage
+#############################################################################
+Usage()
+{
+cat <<EOF
+Usage: board_list [User]"
+    User       : List boards asigned to User, if omitted, use the current user by default."
+    -h|--help  : Display this information"
+EOF
+
+exit 0
+}
+
+if [ $# != 0 ]; then
+	if [[ $1 == "-h" || $1 == "--help" ]]; then
+		Usage
+	fi
+fi
+
+USER=${1:-`whoami`}
+
+#############################################################################
 # Check if user is in userinfo.cfg
 #############################################################################
-if !(get_user_info $USER >/dev/null); then
-	echo "You are not permited to use the board in OpenLab."
+if !(check_user $USER); then
 	exit 1
 fi
 

--- a/board_list
+++ b/board_list
@@ -5,9 +5,10 @@ export PATH=$TOP_DIR/bin:$PATH
 OPENLAB_TOPDIR=/usr/local/openlab
 OPENLAB_CONF_DIR=$OPENLAB_TOPDIR/openlab_conf
 
-USER="`whoami`"
+USER=${1:-`whoami`}
+
 #############################################################################
-#
+# Source common variables and user functions
 #############################################################################
 . $OPENLAB_TOPDIR/Include/common.sh
 . $OPENLAB_TOPDIR/Include/userop.sh
@@ -23,20 +24,23 @@ fi
 #############################################################################
 # List all shared board info
 #############################################################################
+BOARD_IDX_STR="Idx"
+BOARD_NUM_STR="Board No"
+BOARD_TYPE_STR="Board Type"
 echo "${USER} possessed boards list:"
-printf "%3s: %8s %10s -> Shared Users\n" "Idx" "Board No" "Board Type"
+printf "%${#BOARD_IDX_STR}s: %${#BOARD_NUM_STR}s %${#BOARD_TYPE_STR}s -> Shared Users\n" "${BOARD_IDX_STR}" "${BOARD_NUM_STR}" "${BOARD_TYPE_STR}"
 
 user_boards=($(get_user_boards $USER))
 board_num=${#user_boards[@]}
 
-for (( idx=0; idx<board_num; idx++))
+for ((idx=0; idx<board_num; idx++))
 do
 	board_no=${user_boards[$idx]}
 	board_type=$(grep -E "^(BOARD$board_no:).*" $OPENLAB_CONF_DIR/$BOARD_INFO_FILE | grep -Po "(?<=type=)([^ ,]*)")
-	shared_info=`grep -E "boards=.*\b${board_no}\b" $OPENLAB_CONF_DIR/$USER_INFO_FILE | grep -v "${USER}:" | cut -d "," -f1 | sed "s/email=//g" | tr '\n' ";"|sed "s/;/; /g"`
+	shared_info=`grep -E "boards=.*\b${board_no}\b" $OPENLAB_CONF_DIR/$USER_INFO_FILE | grep -v "${USER}:" | cut -d "," -f1 | sed "s/email=//g" | tr '\n' ';'|sed "s/;/; /g"`
 	if [ x"" = x"$shared_info" ]; then
-		printf "%3s: %8s %10s\n" "$[${idx}+1]" "${board_no}" "${board_type}"
+		printf "%${#BOARD_IDX_STR}s: %${#BOARD_NUM_STR}s %${#BOARD_TYPE_STR}s\n" "$((${idx}+1))" "${board_no}" "${board_type}"
 	else
-		printf "%3s: %8s %10s -> %s\n" "$[${idx}+1]" "${board_no}" "${board_type}" "${shared_info}"
+		printf "%${#BOARD_IDX_STR}s: %${#BOARD_NUM_STR}s %${#BOARD_TYPE_STR}s -> %s\n" "$((${idx}+1))" "${board_no}" "${board_type}" "${shared_info}"
 	fi
 done

--- a/board_lock
+++ b/board_lock
@@ -1,0 +1,133 @@
+#!/bin/bash
+TOP_DIR=$(cd "`dirname $0`" ; pwd)
+OPENLAB_TOPDIR=/usr/local/openlab
+OPENLAB_CONF_DIR=$OPENLAB_TOPDIR/openlab_conf
+
+USER="`whoami`"
+
+#############################################################################
+# Include
+#############################################################################
+. $OPENLAB_TOPDIR/Include/common.sh
+. $OPENLAB_TOPDIR/Include/userop.sh
+. $OPENLAB_TOPDIR/Include/boardop.sh
+. $OPENLAB_TOPDIR/Include/telnetop.sh
+
+#############################################################################
+# Usage
+#############################################################################
+Usage()
+{
+cat <<EOF
+Usage: board_lock [-h|--help] [-u|--unlock] [-f|--force] [Num]
+To lock/unlock the board specified, default to lock board1 without any parameters!
+    -h|--help    : Display this information
+    -u|--unlock  : To unlock the board specified, default to unlock board1 if argument Num omitted.
+    -f|--force   : Try to lock/unlock the board specified that locked by other users with sudo permission.
+    Num          : To lock/unlock the specified board assigned to user, Num is an interger board index which must be greater than 0, default to board1.
+
+EOF
+
+exit 0
+}
+
+#############################################################################
+# Check if user is in openlab user list
+#############################################################################
+if !(check_user $USER); then
+	exit 1
+fi
+
+#############################################################################
+# Parse script options
+#############################################################################
+UNLOCK=0
+FORCE=0
+BOARD_INDEX=0
+
+while test $# != 0
+do
+	case $1 in
+	"-h" | "--help")
+		Usage
+		;;
+	"-u" | "--unlock")
+		UNLOCK=1
+		;;
+	"-f" | "--force")
+		FORCE=1
+		;;
+	[1-9]*) # Num
+		BOARD_INDEX=$(($1 - 1))
+		;;
+	*)
+		echo -e "\033[31mInvalid arguments!\033[0m" >&2
+		Usage
+		;;
+	esac
+
+	shift
+done
+
+#############################################################################
+# Get BOARD_NO
+#############################################################################
+BOARD_NO=$(get_board_no $USER $BOARD_INDEX)
+if [ x"$BOARD_NO" = x"" ]; then
+	echo -e "\033[31mInvalid boardNo! Please use board_list to get your board info!\033[0m" >&2 ;
+	exit 1
+fi
+
+#############################################################################
+# Check if board is deployed or being used
+#############################################################################
+if !(board_deploy_chk $BOARD_NO); then
+	exit 1
+fi
+
+if !(board_using_chk $USER $BOARD_NO); then
+	curUser=$(get_board_current_user $BOARD_NO)
+	if [ x"$curUser" != x"" ]; then
+		# the board is currently using by others
+		exit 1
+	fi
+
+	# the board was locked by others
+	if [ $FORCE -eq 0 ]; then
+		# can not lock or unlock the board without force
+		exit 1
+	fi
+
+	# force lock/unlock the board
+	# remove the current board lock file
+	lock_file=$(find_board_lock_file $BOARD_NO)
+	read -n1 -p "Force to lock/unlock the board [Y/N]?" answer
+	case $answer in
+		Y | y)
+			echo ""
+			sudo rm -f $lock_file
+			if [ $? -ne 0 ]; then
+				echo "Board state unchanged."
+				exit 1
+			fi
+			;;
+		*)
+			echo -e "\nBoard state unchanged."
+			exit 1
+			;;
+	esac
+fi
+
+#############################################################################
+# Lock or unlock the board of brdNo
+#############################################################################
+if [ $UNLOCK -eq 0 ]; then
+	# lock the board
+	gen_board_lock_file $USER $BOARD_NO
+	echo "Board $BOARD_NO locked successfully."
+else
+	# unlock the board
+	lock_file=$(find_board_lock_file $BOARD_NO)
+	rm -f $lock_file
+	echo "Board $BOARD_NO unlocked successfully."
+fi

--- a/board_reboot
+++ b/board_reboot
@@ -9,7 +9,6 @@ USER="`whoami`"
 # Global Variable
 #############################################################################
 BOARD_OP="reset"
-
 BOARD_NO=
 BOARD_INDEX=
 SERIAL=
@@ -40,8 +39,7 @@ Usage()
 #############################################################################
 # Check if user is in openlab user list
 #############################################################################
-if !(get_user_info $USER >/dev/null); then
-	echo "You are not permited to use the board in OpenLab."
+if !(check_user $USER); then
 	exit 1
 fi
 
@@ -88,35 +86,25 @@ done
 #############################################################################
 # Get BOARD_NO
 #############################################################################
+BOARD_NO=$(get_board_no $USER $BOARD_INDEX)
 if [ x"$BOARD_NO" = x"" ]; then
-	user_boards=($(get_user_boards $USER))
-	if [ x"$BOARD_INDEX" != x"" ]; then
-		if [ $BOARD_INDEX -lt 0 ] || [ $BOARD_INDEX -ge ${#user_boards[@]} ]; then
-			echo -e "\033[31mInvalid board index! Please use board_list to get your board info!\033[0m" >&2 ; exit 1
-		fi
-		BOARD_NO=${user_boards[$BOARD_INDEX]}
-	else
-		BOARD_NO=${user_boards[0]}
-	fi
+	echo -e "\033[31mInvalid boardNo! Please use board_list to get your board info!\033[0m" >&2 ;
+	exit 1
 fi
 
 #############################################################################
-# Check board and operate the power
+# Check if board is deployed or being used
 #############################################################################
-if !(get_board_info $BOARD_NO >/dev/null); then
-	echo -e "\033[31mCan't find board info! Please touch Lab admin to get more help!\033[0m" ; exit 0
-fi
-
 if !(board_deploy_chk $BOARD_NO); then
 	exit 1
 fi
 
-if !(board_using_chk $BOARD_NO $BOARD_OP); then
+if !(board_using_chk $USER $BOARD_NO); then
 	exit 1
 fi
 
+#############################################################################
+# Power operation
+#############################################################################
 board_power $BOARD_NO $BOARD_OP
 echo ""
-
-
-

--- a/board_reboot
+++ b/board_reboot
@@ -89,14 +89,13 @@ done
 # Get BOARD_NO
 #############################################################################
 if [ x"$BOARD_NO" = x"" ]; then
+	user_boards=($(get_user_boards $USER))
 	if [ x"$BOARD_INDEX" != x"" ]; then
-		user_boards=($(get_user_boards $USER))
 		if [ $BOARD_INDEX -lt 0 ] || [ $BOARD_INDEX -ge ${#user_boards[@]} ]; then
 			echo -e "\033[31mInvalid board index! Please use board_list to get your board info!\033[0m" >&2 ; exit 1
 		fi
 		BOARD_NO=${user_boards[$BOARD_INDEX]}
 	else
-		user_boards=($(get_user_boards $USER))
 		BOARD_NO=${user_boards[0]}
 	fi
 fi

--- a/inituser
+++ b/inituser
@@ -37,10 +37,6 @@ fi
 USER_BOARDS=($(get_user_boards $USER))
 BOARD_NO=${USER_BOARDS[0]}
 
-if !(get_board_info $BOARD_NO >/dev/null); then
-	echo -e "\033[31mCan't find board info ......\033[0m" ; exit 0
-fi
-
 if !(board_deploy_chk $BOARD_NO); then
 	exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ fi
 cp board_connect $BINPATH
 cp board_list $BINPATH
 cp board_reboot $BINPATH
+cp board_lock $BINPATH
 cp newuser $BINPATH
 cp gencfg.sh $BINPATH
 cp inituser $BINPATH


### PR DESCRIPTION
1. fix hard-coding magic numbers
2. support board list for other users as well as the current user
3. make variables in functions to be local
4. reduce duplicative code by reusing functions preferable
5. make function more effective avoid using subshell
6. add board_lock command

Usage: board_lock [-h|--help] [-u|--unlock] [-f|--force] [Num]
To lock/unlock the board specified, default to lock board1 without any parameters!
    -h|--help    : Display this information
    -u|--unlock  : To unlock the board specified, default to unlock board1 if argument Num omitted.
    -f|--force   : Try to lock/unlock the board specified that locked by other users with sudo permission.
    Num          : To lock/unlock the specified board assigned to user, Num is an interger board index which must be greater than 0, default to board1.
